### PR TITLE
Fix: Keep entries sorted in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-/.github/           export-ignore
 /.dependabot/       export-ignore
+/.github/           export-ignore
 /.travis/           export-ignore
 /test/              export-ignore
 /.editorconfig      export-ignore


### PR DESCRIPTION
This PR

* [x] keeps entries sorted in `.gitattributes`