### PR TITLE
Enhancement: Configure phpstan to infer private property types from constructor

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ includes:
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 
 parameters:
+	inferPrivatePropertyTypeFromConstructor: true
 	paths:
 		- src
 		- test

--- a/src/Example.php
+++ b/src/Example.php
@@ -15,9 +15,6 @@ namespace Localheinz\Library;
 
 final class Example
 {
-    /**
-     * @var string
-     */
     private $name;
 
     private function __construct(string $name)


### PR DESCRIPTION
This PR

* [x] configures `phpstan` to infer private property types from constructor
* [x] removes a useless DocBlock

Follows #33. 