### PR TITLE
Fix: Validate composer.json and composer.lock with --strict option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       before_install:
         - source .travis/xdebug.sh
         - xdebug-disable
-        - composer validate
+        - composer validate --strict
         - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
       install:
@@ -46,7 +46,7 @@ jobs:
       before_install:
         - source .travis/xdebug.sh
         - xdebug-disable
-        - composer validate
+        - composer validate --strict
         - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
       install:
@@ -69,7 +69,7 @@ jobs:
       before_install:
         - source .travis/xdebug.sh
         - xdebug-disable
-        - composer validate
+        - composer validate --strict
         - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
       install:
@@ -128,7 +128,7 @@ jobs:
       before_install:
         - source .travis/xdebug.sh
         - xdebug-disable
-        - composer validate
+        - composer validate --strict
         - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
       install:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,6 @@ test: vendor
 	vendor/bin/phpunit --configuration=test/Integration/phpunit.xml
 
 vendor: composer.json composer.lock
-	composer validate
+	composer validate --strict
 	composer install
 	composer normalize


### PR DESCRIPTION
This PR

* [x] uses the `--strict` option when running `composer validate`