### PR TITLE
Enhancement: Use actions/stale instead of probot/stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,9 +1,0 @@
-# https://github.com/probot/stale
-
-daysUntilClose: 7
-daysUntilStale: 60
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-staleLabel: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+# https://github.com/actions/stale
+
+name: "Close stale issues and pull requests"
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 60
+          days-before-close: 5
+          stale-issue-label: 'stale'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          stale-pr-label: 'stale'


### PR DESCRIPTION
This PR

* [x] uses `actions/stale` instead of `probot/stale`

💁‍♂ For reference, see https://github.com/actions/stale.