### PR TITLE
Enhancement: Increase versions when updating dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,4 +10,4 @@ update_configs:
     directory: "/"
     package_manager: "php:composer"
     update_schedule: "live"
-    version_requirement_updates: "auto"
+    version_requirement_updates: "increase_versions"


### PR DESCRIPTION
This PR

* [x] adjusts the `version_requirement_updates` configuration for Dependabot to increase versions in `composer.json` as well

💁‍♂ For reference, see https://dependabot.com/docs/config-file/#available-update-strategies.