### PR TITLE
Fix: Do not bother validating composer.json twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,6 @@ jobs:
         with:
           args: php -v
 
-      - name: Validate composer.json and composer.lock
-        uses: ./.docker/php-7.3
-        with:
-          args: composer validate --strict
-
       - name: Install dependencies with composer
         uses: ./.docker/php-7.3
         with:


### PR DESCRIPTION
This PR

* [x] runs `composer validate --strict` only in the `style` job

Follows #66.