### PR TITLE
Enhancement: Reference ci.yml as required status check

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -10,10 +10,7 @@ branches:
         required_approving_review_count: 1
       required_status_checks:
         contexts:
-          - "Coding Standards"
-          - "Static Code Analysis"
-          - "Code Coverage"
-          - "Mutation Tests"
+          -  ".github/workflows/ci.yml"
         strict: false
       restrictions: null
 


### PR DESCRIPTION
This PR

* [x] references `ci.yml` as required status check