### PR TITLE
Fix: Use job names for required status checks

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -10,7 +10,11 @@ branches:
         required_approving_review_count: 1
       required_status_checks:
         contexts:
-          -  ".github/workflows/ci.yml"
+          -  "Code Coverage"
+          -  "Coding Standards"
+          -  "Mutation Tests"
+          -  "Static Code Analysis"
+          -  "Tests"
         strict: false
       restrictions: null
 


### PR DESCRIPTION
This PR

* [x] uses job names for required status checks

Follows #73.