### PR TITLE
Fix: Do not collect code coverage before running mutation tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -206,11 +206,6 @@ jobs:
         with:
           args: vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --dump-xdebug-filter=.build/phpunit/xdebug-filter.php
 
-      - name: "Collect coverage with Xdebug and phpunit/phpunit"
-        uses: docker://localheinz/php-library-template-php-7.3-with-xdebug
-        with:
-          args: vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-clover=build/logs/clover.xml --prepend=.build/phpunit/xdebug-filter.php
-
       - name: "Run mutation tests with infection/infection"
         uses: docker://localheinz/php-library-template-php-7.3-with-xdebug
         with:


### PR DESCRIPTION
This PR

* [x] stops collecting code coverage before running mutation tests