### PR TITLE
Fix: Require codecov/patch and codecov/project to pass

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -20,6 +20,8 @@ branches:
           -  "Tests on PHP 7.3 (highest)"
           -  "Code Coverage"
           -  "Mutation Tests"
+          -  "codecov/patch"
+          -  "codecov/project"
         strict: false
       restrictions: null
 


### PR DESCRIPTION
This PR

* [x] requires `codecov/patch` and `codecov/project` to pass