### PR TITLE
Fix: Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # php-library-template
 
-[![CI Status](https://github.com/localheinz/php-library-template/workflows/CI/badge.svg)](https://github.com/localheinz/php-library-template/actions)
+[![CI Status](https://github.com/localheinz/php-library-template/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/php-library-template/actions)
 [![codecov](https://codecov.io/gh/localheinz/php-library-template/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/php-library-template)
 [![Latest Stable Version](https://poser.pugx.org/localheinz/php-library-template/v/stable)](https://packagist.org/packages/localheinz/php-library-template)
 [![Total Downloads](https://poser.pugx.org/localheinz/php-library-template/downloads)](https://packagist.org/packages/localheinz/php-library-template)


### PR DESCRIPTION
This PR

* [x] fixes the URL for the GitHub actions status badge

💁‍♂ For reference, see https://help.github.com/en/articles/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository.