### PR TITLE
Fix: Do not bother ignoring non-existent directory

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -30,7 +30,6 @@ $config->getFinder()
     ->exclude([
         '.build',
         '.dependabot',
-        '.docker',
         '.github',
     ])
     ->name('.php_cs');


### PR DESCRIPTION
This PR

* [x] removes a non-existent directory from an ignore list