### PR TITLE
Fix: Remove phpbench files

### DIFF
--- a/phpbench.json
+++ b/phpbench.json
@@ -1,4 +1,0 @@
-{
-  "bootstrap": "vendor/autoload.php",
-  "path": "test/Bench"
-}


### PR DESCRIPTION
This PR

* [x] removes unneeded `phpbench` files

Follows #90.