### PR TITLE
Less noisy composer install steps

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
         run: php7.2 /usr/bin/composer validate --strict
 
       - name: "Install locked dependencies with composer"
-        run: php7.2 /usr/bin/composer install
+        run: php7.2 /usr/bin/composer install --no-interaction --no-progress --no-suggest
 
       - name: "Run localheinz/composer-normalize"
         run: php7.2 /usr/bin/composer normalize --dry-run
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: "Install locked dependencies with composer"
-        run: php7.2 /usr/bin/composer install
+        run: php7.2 /usr/bin/composer install --no-interaction --no-progress --no-suggest
 
       - name: "Run phpstan/phpstan"
         run: php7.2 vendor/bin/phpstan analyse --configuration=phpstan.neon
@@ -65,15 +65,15 @@ jobs:
 
       - name: "Install lowest dependencies with composer"
         if: matrix.dependencies == 'lowest'
-        run: ${{ matrix.php-binary }} /usr/bin/composer update --prefer-lowest
+        run: ${{ matrix.php-binary }} /usr/bin/composer update --prefer-lowest --no-interaction --no-progress --no-suggest
 
       - name: "Install locked dependencies with composer"
         if: matrix.dependencies == 'locked'
-        run: ${{ matrix.php-binary }} /usr/bin/composer install
+        run: ${{ matrix.php-binary }} /usr/bin/composer install --no-interaction --no-progress --no-suggest
 
       - name: "Install highest dependencies with composer"
         if: matrix.dependencies == 'highest'
-        run: ${{ matrix.php-binary }} /usr/bin/composer update
+        run: ${{ matrix.php-binary }} /usr/bin/composer update --no-interaction --no-progress --no-suggest
 
       - name: "Run auto-review tests with phpunit/phpunit"
         run: ${{ matrix.php-binary }} vendor/bin/phpunit --configuration=test/AutoReview/phpunit.xml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: "Install locked dependencies with composer"
-        run: php7.3 /usr/bin/composer install
+        run: php7.3 /usr/bin/composer install --no-interaction --no-progress --no-suggest
 
       - name: "Dump Xdebug filter with phpunit/phpunit"
         run: php7.3 vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --dump-xdebug-filter=.build/phpunit/xdebug-filter.php
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: "Install locked dependencies with composer"
-        run: php7.3 /usr/bin/composer install
+        run: php7.3 /usr/bin/composer install --no-interaction --no-progress --no-suggest
 
       - name: "Run mutation tests with infection/infection"
         run: php7.3 vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=100 --min-msi=100


### PR DESCRIPTION
This PR

* [x] limits the output of composer install and update in CI to reasonable levels
