### PR TITLE
Enhancement: Reduce noise from Makefile as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,5 @@ test: vendor ## Runs auto-review, unit, and integration tests with phpunit
 
 vendor: composer.json composer.lock
 	composer validate --strict
-	composer install
+	composer install --no-interaction --no-progress --no-suggest
 	composer normalize


### PR DESCRIPTION
This PR

* [x] reduces noise when installing dependencies with `composer` in `vendor` target of `Makefile` as well

Follows #99.