### PR TITLE
Enhancement: Use Octocat in repository description

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -43,7 +43,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   default_branch: master
-  description: ":ledger: Provides a GitHub repository template for a PHP library."
+  description: ":octocat: + :ledger: Provides a GitHub repository template for a PHP library."
   has_downloads: true
   has_issues: true
   has_pages: false


### PR DESCRIPTION
This PR

* [x] uses :octocat: in the repository description