### PR TITLE
Fix: Fail build when code coverage upload failed

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,7 +106,7 @@ jobs:
         run: curl -s https://codecov.io/bash -o codecov
 
       - name: "Send code coverage report to Codecov.io"
-        run: bash codecov -t ${{ secrets.CODECOV_TOKEN }}
+        run: bash codecov -t ${{ secrets.CODECOV_TOKEN }} -Z
 
   mutation-tests:
     name: "Mutation Tests"


### PR DESCRIPTION
This PR

* [x] fails the build when the code coverage upload failed