### PR TITLE
Fix: Do not fail step when sending code coverage failed

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,7 +106,7 @@ jobs:
         run: curl -s https://codecov.io/bash -o codecov
 
       - name: "Send code coverage report to Codecov.io"
-        run: bash codecov -t ${{ secrets.CODECOV_TOKEN }} -Z
+        run: bash codecov -t ${{ secrets.CODECOV_TOKEN }}
 
   mutation-tests:
     name: "Mutation Tests"


### PR DESCRIPTION
This PR

* [x] stops failing a step when code coverage could not be send

💁‍♂ For reference, see 

* https://github.com/sebastianbergmann/phpunit/pull/3833
* https://github.com/codecov/codecov-bash/pull/199