### PR TITLE
GitHub Actions: cache composer dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,9 +29,9 @@ jobs:
         id: cache
         with:
           path: ~/.composer/cache/files
-          key: composer-cache-${{ github.ref }}
+          key: composer-cache-${{ github.sha }}
           restore-keys: |
-            composer-cache-${{ github.ref }}
+            composer-cache-${{ github.sha }}
             composer-cache
 
       - name: "Install locked dependencies with composer"
@@ -61,9 +61,9 @@ jobs:
         id: cache
         with:
           path: ~/.composer/cache/files
-          key: composer-cache-${{ github.ref }}
+          key: composer-cache-${{ github.sha }}
           restore-keys: |
-            composer-cache-${{ github.ref }}
+            composer-cache-${{ github.sha }}
             composer-cache
 
       - name: "Install locked dependencies with composer"
@@ -101,9 +101,9 @@ jobs:
         id: cache
         with:
           path: ~/.composer/cache/files
-          key: composer-cache-${{ github.ref }}
+          key: composer-cache-${{ github.sha }}
           restore-keys: |
-            composer-cache-${{ github.ref }}
+            composer-cache-${{ github.sha }}
             composer-cache
 
       - name: "Install lowest dependencies with composer"
@@ -142,9 +142,9 @@ jobs:
         id: cache
         with:
           path: ~/.composer/cache/files
-          key: composer-cache-${{ github.ref }}
+          key: composer-cache-${{ github.sha }}
           restore-keys: |
-            composer-cache-${{ github.ref }}
+            composer-cache-${{ github.sha }}
             composer-cache
 
       - name: "Install locked dependencies with composer"
@@ -177,9 +177,9 @@ jobs:
         id: cache
         with:
           path: ~/.composer/cache/files
-          key: composer-cache-${{ github.ref }}
+          key: composer-cache-${{ github.sha }}
           restore-keys: |
-            composer-cache-${{ github.ref }}
+            composer-cache-${{ github.sha }}
             composer-cache
 
       - name: "Install locked dependencies with composer"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: ${COMPOSER_HOME}/cache/files
+          path: ~/.composer/cache/files
           key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
@@ -55,7 +55,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: ${COMPOSER_HOME}/cache/files
+          path: ~/.composer/cache/files
           key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
@@ -93,7 +93,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: ${COMPOSER_HOME}/cache/files
+          path: ~/.composer/cache/files
           key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
@@ -132,7 +132,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: ${COMPOSER_HOME}/cache/files
+          path: ~/.composer/cache/files
           key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
@@ -165,7 +165,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: ${COMPOSER_HOME}/cache/files
+          path: ~/.composer/cache/files
           key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,15 +22,14 @@ jobs:
       - name: "Validate composer.json and composer.lock"
         run: php7.2 $(which composer) validate --strict
 
-      - name: "Restore composer dependencies"
+      - name: "Cache composer dependencies"
         uses: actions/cache@preview
-        id: cache
         with:
-          path: ~/.composer/cache/files
-          key: composer-cache-${{ github.sha }}
+          path: $COMPOSER_HOME/cache/files
+          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
-            composer-cache-${{ github.sha }}
-            composer-cache
+            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
+            composer-
 
       - name: "Install locked dependencies with composer"
         run: php7.2 $(which composer) install --no-interaction --no-progress --no-suggest
@@ -53,15 +52,14 @@ jobs:
       - name: "Disable Xdebug"
         run: php7.3 --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
 
-      - name: "Restore composer dependencies"
+      - name: "Cache composer dependencies"
         uses: actions/cache@preview
-        id: cache
         with:
-          path: ~/.composer/cache/files
-          key: composer-cache-${{ github.sha }}
+          path: $COMPOSER_HOME/cache/files
+          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
-            composer-cache-${{ github.sha }}
-            composer-cache
+            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
+            composer-
 
       - name: "Install locked dependencies with composer"
         run: php7.3 $(which composer) install --no-interaction --no-progress --no-suggest
@@ -92,15 +90,14 @@ jobs:
       - name: "Disable Xdebug"
         run: ${{ matrix.php-binary }} --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
 
-      - name: "Restore composer dependencies"
+      - name: "Cache composer dependencies"
         uses: actions/cache@preview
-        id: cache
         with:
-          path: ~/.composer/cache/files
-          key: composer-cache-${{ github.sha }}
+          path: $COMPOSER_HOME/cache/files
+          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
-            composer-cache-${{ github.sha }}
-            composer-cache
+            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
+            composer-
 
       - name: "Install lowest dependencies with composer"
         if: matrix.dependencies == 'lowest'
@@ -132,15 +129,14 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@master
 
-      - name: "Restore composer dependencies"
+      - name: "Cache composer dependencies"
         uses: actions/cache@preview
-        id: cache
         with:
-          path: ~/.composer/cache/files
-          key: composer-cache-${{ github.sha }}
+          path: $COMPOSER_HOME/cache/files
+          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
-            composer-cache-${{ github.sha }}
-            composer-cache
+            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
+            composer-
 
       - name: "Install locked dependencies with composer"
         run: php7.3 $(which composer) install --no-interaction --no-progress --no-suggest
@@ -166,15 +162,14 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@master
 
-      - name: "Restore composer dependencies"
+      - name: "Cache composer dependencies"
         uses: actions/cache@preview
-        id: cache
         with:
-          path: ~/.composer/cache/files
-          key: composer-cache-${{ github.sha }}
+          path: $COMPOSER_HOME/cache/files
+          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
-            composer-cache-${{ github.sha }}
-            composer-cache
+            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
+            composer-
 
       - name: "Install locked dependencies with composer"
         run: php7.3 $(which composer) install --no-interaction --no-progress --no-suggest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,9 +26,8 @@ jobs:
         uses: actions/cache@preview
         with:
           path: ~/.composer/cache/files
-          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
+          key: composer-${{ github.sha }}
           restore-keys: |
-            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
             composer-
 
       - name: "Install locked dependencies with composer"
@@ -56,9 +55,8 @@ jobs:
         uses: actions/cache@preview
         with:
           path: ~/.composer/cache/files
-          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
+          key: composer-${{ github.sha }}
           restore-keys: |
-            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
             composer-
 
       - name: "Install locked dependencies with composer"
@@ -94,10 +92,9 @@ jobs:
         uses: actions/cache@preview
         with:
           path: ~/.composer/cache/files
-          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ matrix.php-binary }}-${{ matrix.dependencies }}-${{ github.sha }}
+          key: composer-${{ matrix.php-binary }}-${{ matrix.dependencies }}-${{ github.sha }}
           restore-keys: |
-            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ matrix.php-binary }}-${{ matrix.dependencies }}-
-            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
+            composer-${{ matrix.php-binary }}-${{ matrix.dependencies }}-
             composer-
 
       - name: "Install lowest dependencies with composer"
@@ -134,9 +131,8 @@ jobs:
         uses: actions/cache@preview
         with:
           path: ~/.composer/cache/files
-          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
+          key: composer-${{ github.sha }}
           restore-keys: |
-            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
             composer-
 
       - name: "Install locked dependencies with composer"
@@ -167,9 +163,8 @@ jobs:
         uses: actions/cache@preview
         with:
           path: ~/.composer/cache/files
-          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
+          key: composer-${{ github.sha }}
           restore-keys: |
-            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
             composer-
 
       - name: "Install locked dependencies with composer"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -94,8 +94,9 @@ jobs:
         uses: actions/cache@preview
         with:
           path: ~/.composer/cache/files
-          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
+          key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ matrix.php-binary }}-${{ matrix.dependencies }}-${{ github.sha }}
           restore-keys: |
+            composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ matrix.php-binary }}-${{ matrix.dependencies }}-
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
             composer-
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
         run: php7.2 $(which composer) validate --strict
 
       - name: "Cache composer dependencies"
-        uses: actions/cache@preview
+        uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
           key: composer-${{ github.sha }}
@@ -52,7 +52,7 @@ jobs:
         run: php7.3 --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
 
       - name: "Cache composer dependencies"
-        uses: actions/cache@preview
+        uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
           key: composer-${{ github.sha }}
@@ -89,7 +89,7 @@ jobs:
         run: ${{ matrix.php-binary }} --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
 
       - name: "Cache composer dependencies"
-        uses: actions/cache@preview
+        uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
           key: composer-${{ matrix.php-binary }}-${{ matrix.dependencies }}-${{ github.sha }}
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: "Cache composer dependencies"
-        uses: actions/cache@preview
+        uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
           key: composer-${{ github.sha }}
@@ -160,7 +160,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: "Cache composer dependencies"
-        uses: actions/cache@preview
+        uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
           key: composer-${{ github.sha }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,8 +22,6 @@ jobs:
       - name: "Validate composer.json and composer.lock"
         run: php7.2 $(which composer) validate --strict
 
-      - run: env
-
       - name: "Restore composer dependencies"
         uses: actions/cache@preview
         id: cache
@@ -55,7 +53,6 @@ jobs:
       - name: "Disable Xdebug"
         run: php7.3 --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
 
-      - run: env
       - name: "Restore composer dependencies"
         uses: actions/cache@preview
         id: cache
@@ -95,7 +92,6 @@ jobs:
       - name: "Disable Xdebug"
         run: ${{ matrix.php-binary }} --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
 
-      - run: env
       - name: "Restore composer dependencies"
         uses: actions/cache@preview
         id: cache
@@ -136,7 +132,6 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@master
 
-      - run: env
       - name: "Restore composer dependencies"
         uses: actions/cache@preview
         id: cache
@@ -171,7 +166,6 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@master
 
-      - run: env
       - name: "Restore composer dependencies"
         uses: actions/cache@preview
         id: cache

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,6 +22,16 @@ jobs:
       - name: "Validate composer.json and composer.lock"
         run: php7.2 $(which composer) validate --strict
 
+      - name: "Restore composer dependencies"
+        uses: actions/cache@preview
+        id: cache
+        with:
+          path: ~/.composer/cache/files
+          key: composer-cache-${{ github.ref }}
+          restore-keys: |
+            composer-cache-${{ github.ref }}
+            composer-cache
+
       - name: "Install locked dependencies with composer"
         run: php7.2 $(which composer) install --no-interaction --no-progress --no-suggest
 
@@ -42,6 +52,16 @@ jobs:
 
       - name: "Disable Xdebug"
         run: php7.3 --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
+
+      - name: "Restore composer dependencies"
+        uses: actions/cache@preview
+        id: cache
+        with:
+          path: ~/.composer/cache/files
+          key: composer-cache-${{ github.ref }}
+          restore-keys: |
+            composer-cache-${{ github.ref }}
+            composer-cache
 
       - name: "Install locked dependencies with composer"
         run: php7.3 $(which composer) install --no-interaction --no-progress --no-suggest
@@ -71,6 +91,16 @@ jobs:
 
       - name: "Disable Xdebug"
         run: ${{ matrix.php-binary }} --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
+
+      - name: "Restore composer dependencies"
+        uses: actions/cache@preview
+        id: cache
+        with:
+          path: ~/.composer/cache/files
+          key: composer-cache-${{ github.ref }}
+          restore-keys: |
+            composer-cache-${{ github.ref }}
+            composer-cache
 
       - name: "Install lowest dependencies with composer"
         if: matrix.dependencies == 'lowest'
@@ -102,6 +132,16 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@master
 
+      - name: "Restore composer dependencies"
+        uses: actions/cache@preview
+        id: cache
+        with:
+          path: ~/.composer/cache/files
+          key: composer-cache-${{ github.ref }}
+          restore-keys: |
+            composer-cache-${{ github.ref }}
+            composer-cache
+
       - name: "Install locked dependencies with composer"
         run: php7.3 $(which composer) install --no-interaction --no-progress --no-suggest
 
@@ -125,6 +165,16 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@master
+
+      - name: "Restore composer dependencies"
+        uses: actions/cache@preview
+        id: cache
+        with:
+          path: ~/.composer/cache/files
+          key: composer-cache-${{ github.ref }}
+          restore-keys: |
+            composer-cache-${{ github.ref }}
+            composer-cache
 
       - name: "Install locked dependencies with composer"
         run: php7.3 $(which composer) install --no-interaction --no-progress --no-suggest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: php7.2-composer-locked-${{ github.sha }}
+          key: php7.2-composer-locked-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             php7.2-composer-locked-
 
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: php7.3-composer-locked-${{ github.sha }}
+          key: php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             php7.3-composer-locked-
 
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-${{ github.sha }}
+          key: ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-
 
@@ -130,7 +130,7 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: php7.3-composer-locked-${{ github.sha }}
+          key: php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             php7.3-composer-locked-
 
@@ -162,7 +162,7 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: php7.3-composer-locked-${{ github.sha }}
+          key: php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             php7.3-composer-locked-
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
       - name: "Validate composer.json and composer.lock"
         run: php7.2 $(which composer) validate --strict
 
-      - name: "Cache composer dependencies"
+      - name: "Cache dependencies installed with composer"
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
@@ -51,7 +51,7 @@ jobs:
       - name: "Disable Xdebug"
         run: php7.3 --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
 
-      - name: "Cache composer dependencies"
+      - name: "Cache dependencies installed with composer"
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
@@ -88,7 +88,7 @@ jobs:
       - name: "Disable Xdebug"
         run: ${{ matrix.php-binary }} --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
 
-      - name: "Cache composer dependencies"
+      - name: "Cache dependencies installed with composer"
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
@@ -127,7 +127,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@master
 
-      - name: "Cache composer dependencies"
+      - name: "Cache dependencies installed with composer"
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
@@ -159,7 +159,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@master
 
-      - name: "Cache composer dependencies"
+      - name: "Cache dependencies installed with composer"
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: $COMPOSER_HOME/cache/files
+          path: ${COMPOSER_HOME}/cache/files
           key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
@@ -55,7 +55,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: $COMPOSER_HOME/cache/files
+          path: ${COMPOSER_HOME}/cache/files
           key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
@@ -93,7 +93,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: $COMPOSER_HOME/cache/files
+          path: ${COMPOSER_HOME}/cache/files
           key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
@@ -132,7 +132,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: $COMPOSER_HOME/cache/files
+          path: ${COMPOSER_HOME}/cache/files
           key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-
@@ -165,7 +165,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: $COMPOSER_HOME/cache/files
+          path: ${COMPOSER_HOME}/cache/files
           key: composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-${{ github.sha }}
           restore-keys: |
             composer-${{ hashFiles(format('{0}{1}', github.workspace, '/composer.json'))}}-

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: composer-${{ github.sha }}
+          key: php7.2-composer-locked-${{ github.sha }}
           restore-keys: |
-            composer-
+            php7.2-composer-locked-
 
       - name: "Install locked dependencies with composer"
         run: php7.2 $(which composer) install --no-interaction --no-progress --no-suggest
@@ -55,9 +55,9 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: composer-${{ github.sha }}
+          key: php7.3-composer-locked-${{ github.sha }}
           restore-keys: |
-            composer-
+            php7.3-composer-locked-
 
       - name: "Install locked dependencies with composer"
         run: php7.3 $(which composer) install --no-interaction --no-progress --no-suggest
@@ -92,10 +92,9 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: composer-${{ matrix.php-binary }}-${{ matrix.dependencies }}-${{ github.sha }}
+          key: ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-${{ github.sha }}
           restore-keys: |
-            composer-${{ matrix.php-binary }}-${{ matrix.dependencies }}-
-            composer-
+            ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-
 
       - name: "Install lowest dependencies with composer"
         if: matrix.dependencies == 'lowest'
@@ -131,9 +130,9 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: composer-${{ github.sha }}
+          key: php7.3-composer-locked-${{ github.sha }}
           restore-keys: |
-            composer-
+            php7.3-composer-locked-
 
       - name: "Install locked dependencies with composer"
         run: php7.3 $(which composer) install --no-interaction --no-progress --no-suggest
@@ -163,9 +162,9 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: composer-${{ github.sha }}
+          key: php7.3-composer-locked-${{ github.sha }}
           restore-keys: |
-            composer-
+            php7.3-composer-locked-
 
       - name: "Install locked dependencies with composer"
         run: php7.3 $(which composer) install --no-interaction --no-progress --no-suggest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: ~/.composer/cache/files
+          path: ~/.composer/cache
           key: composer-${{ github.sha }}
           restore-keys: |
             composer-
@@ -54,7 +54,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: ~/.composer/cache/files
+          path: ~/.composer/cache
           key: composer-${{ github.sha }}
           restore-keys: |
             composer-
@@ -91,7 +91,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: ~/.composer/cache/files
+          path: ~/.composer/cache
           key: composer-${{ matrix.php-binary }}-${{ matrix.dependencies }}-${{ github.sha }}
           restore-keys: |
             composer-${{ matrix.php-binary }}-${{ matrix.dependencies }}-
@@ -130,7 +130,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: ~/.composer/cache/files
+          path: ~/.composer/cache
           key: composer-${{ github.sha }}
           restore-keys: |
             composer-
@@ -162,7 +162,7 @@ jobs:
       - name: "Cache composer dependencies"
         uses: actions/cache@preview
         with:
-          path: ~/.composer/cache/files
+          path: ~/.composer/cache
           key: composer-${{ github.sha }}
           restore-keys: |
             composer-

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,6 +22,8 @@ jobs:
       - name: "Validate composer.json and composer.lock"
         run: php7.2 $(which composer) validate --strict
 
+      - run: env
+
       - name: "Restore composer dependencies"
         uses: actions/cache@preview
         id: cache
@@ -53,6 +55,7 @@ jobs:
       - name: "Disable Xdebug"
         run: php7.3 --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
 
+      - run: env
       - name: "Restore composer dependencies"
         uses: actions/cache@preview
         id: cache
@@ -92,6 +95,7 @@ jobs:
       - name: "Disable Xdebug"
         run: ${{ matrix.php-binary }} --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
 
+      - run: env
       - name: "Restore composer dependencies"
         uses: actions/cache@preview
         id: cache
@@ -132,6 +136,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@master
 
+      - run: env
       - name: "Restore composer dependencies"
         uses: actions/cache@preview
         id: cache
@@ -166,6 +171,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@master
 
+      - run: env
       - name: "Restore composer dependencies"
         uses: actions/cache@preview
         id: cache


### PR DESCRIPTION
This PR

* [x] Caches Composer dependencies between workflows.

So there are two strategies here,
1. Simple caching on the hash of `composer.lock`
2. Try to maintain a global cache used across all jobs, which will work when `composer.lock` is not committed.

Strategy number 2 is committed here.
You'll notice the deps are cached for for all combinations of the `tests` job.

cc @teohhanhui