### PR TITLE
Fix: Use commit hash to calculate cache key

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: php7.2-composer-locked-${{ hashFiles('**/composer.lock') }}
+          key: php7.2-composer-locked-${{ github.sha }}
           restore-keys: |
             php7.2-composer-locked-
 
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
+          key: php7.3-composer-locked-${{ github.sha }}
           restore-keys: |
             php7.3-composer-locked-
 
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
+          key: ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-${{ github.sha }}
           restore-keys: |
             ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-
 
@@ -130,7 +130,7 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
+          key: php7.3-composer-locked-${{ github.sha }}
           restore-keys: |
             php7.3-composer-locked-
 
@@ -162,7 +162,7 @@ jobs:
         uses: actions/cache@v1.0.0
         with:
           path: ~/.composer/cache
-          key: php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
+          key: php7.3-composer-locked-${{ github.sha }}
           restore-keys: |
             php7.3-composer-locked-
 


### PR DESCRIPTION
This PR

* [x] uses the commit hash to calculate cache key

💁‍♂ For reference, see https://github.com/actions/cache/issues/65.

Looks like you're right, @bendavies, this indeed works better.