### PR TITLE
Fix: Use version for actions/checkout

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@master
+        uses: actions/checkout@v1.1.0
 
       - name: "Disable Xdebug"
         run: php7.2 --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@master
+        uses: actions/checkout@v1.1.0
 
       - name: "Disable Xdebug"
         run: php7.3 --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@master
+        uses: actions/checkout@v1.1.0
 
       - name: "Disable Xdebug"
         run: ${{ matrix.php-binary }} --ini | grep xdebug | sed 's/,$//' | xargs sudo rm
@@ -124,7 +124,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@master
+        uses: actions/checkout@v1.1.0
 
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v1.0.0
@@ -155,7 +155,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@master
+        uses: actions/checkout@v1.1.0
 
       - name: "Cache dependencies installed with composer"
         uses: actions/cache@v1.0.0


### PR DESCRIPTION
This PR

* [x] uses a version for `actions/checkout` instead of `master`