### PR TITLE
Prevent CI to run twice on Pull Request

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,8 +1,11 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - master
+    tags: "(v?)*.*.*"
+  pull_request:
 
 name: "Continuous Integration"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,11 +1,11 @@
 # https://help.github.com/en/categories/automating-your-workflow-with-github-actions
 
 on:
+  pull_request:
   push:
     branches:
       - master
     tags: "(v?)*.*.*"
-  pull_request:
 
 name: "Continuous Integration"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,8 @@ on:
   push:
     branches:
       - master
-    tags: "(v?)*.*.*"
+    tags:
+      - "**"
 
 name: "Continuous Integration"
 


### PR DESCRIPTION
This PR

* [x] Tweaks CI to run only on push to master or tagged new versions and on pull request

This makes the CI to run only once on new pull request.