### PR TITLE
Fix: Remove redundant cache key

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,6 @@ jobs:
           path: ~/.composer/cache
           key: php7.2-composer-locked-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            php7.2-composer-locked-${{ hashFiles('**/composer.lock') }}
             php7.2-composer-locked-
 
       - name: "Install locked dependencies with composer"
@@ -62,7 +61,6 @@ jobs:
           path: ~/.composer/cache
           key: php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
             php7.3-composer-locked-
 
       - name: "Install locked dependencies with composer"
@@ -100,7 +98,6 @@ jobs:
           path: ~/.composer/cache
           key: ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
             ${{ matrix.php-binary }}-composer-${{ matrix.dependencies }}-
 
       - name: "Install lowest dependencies with composer"
@@ -139,7 +136,6 @@ jobs:
           path: ~/.composer/cache
           key: php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
             php7.3-composer-locked-
 
       - name: "Install locked dependencies with composer"
@@ -171,7 +167,6 @@ jobs:
           path: ~/.composer/cache
           key: php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            php7.3-composer-locked-${{ hashFiles('**/composer.lock') }}
             php7.3-composer-locked-
 
       - name: "Install locked dependencies with composer"


### PR DESCRIPTION
This PR

* [x] removes a redundant cache key

Follows https://github.com/localheinz/php-library-template/pull/145#discussion_r344034156.