### PR TITLE
Fix: Run php-cs-fixer with --dry-run option

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,7 +41,7 @@ jobs:
         run: php7.2 $(which composer) normalize --dry-run
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: php7.2 vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --using-cache=no --verbose
+        run: php7.2 vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --dry-run --using-cache=no --verbose
 
   static-code-analysis:
     name: "Static Code Analysis"


### PR DESCRIPTION
This PR

* [x] runs `php-cs-fixer` using the `--dry-run` option

Follows #93.